### PR TITLE
CacheKey uses only UserAgent for Equals and GetHashCode

### DIFF
--- a/src/MyCSharp.HttpUserAgentParser.MemoryCache/HttpUserAgentParserMemoryCachedProvider.cs
+++ b/src/MyCSharp.HttpUserAgentParser.MemoryCache/HttpUserAgentParserMemoryCachedProvider.cs
@@ -50,20 +50,10 @@ namespace MyCSharp.HttpUserAgentParser.MemoryCache
 
             public HttpUserAgentParserMemoryCachedProviderOptions Options { get; set; } = null!;
 
-            public bool Equals(CacheKey? other)
-            {
-                if (ReferenceEquals(this, other)) return true;
-                if (other is null) return false;
+            public bool Equals(CacheKey? other) => this.UserAgent == other?.UserAgent;
+            public override bool Equals(object? obj) => this.Equals(obj as CacheKey);
 
-                return this.UserAgent == other.UserAgent && this.Options == other.Options;
-            }
-
-            public override bool Equals(object? obj)
-            {
-                return this.Equals(obj as CacheKey);
-            }
-
-            public override int GetHashCode() => HashCode.Combine(this.UserAgent, this.Options);
+            public override int GetHashCode() => this.UserAgent.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mycsharp/HttpUserAgentParser/issues/4

See https://github.com/mycsharp/HttpUserAgentParser/pull/1#discussion_r633338153 for background.
I believe that's enough, @BenjaminAbt what do you think?